### PR TITLE
(ci) Add workflow to build HBC on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update && \
-        sudo apt install -y gcc sox gettext libpng-dev xxd
+        sudo apt install -y gcc sox gettext libpng-dev xxd python2
     - name: Build WiiPAX
       run: |
         cd wiipax

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
       run: |
         mkdir ~/.wii/
         echo $WII_COMMON_KEY > ~/.wii/common-key
+    - name: Install Dependencies
+      run: |
+        sudo apt update && \
+        sudo apt install -y sox gettext libpng-dev xxd
     - name: Build WiiPAX
       run: |
         cd wiipax

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ jobs:
     name: Build using devkitPPC via Docker
     steps:
     - uses: actions/checkout@v4
-    - name: Store Common Key
+    - name: Retrieve Common Key from Secret
       shell: bash
       env:
         WII_COMMON_KEY: ${{ secrets.WII_COMMON_KEY }}
       run: |
         mkdir ~/.wii/
-        echo $WII_COMMON_KEY > ~/.wii/common-key
+        echo $WII_COMMON_KEY | base64 --decode > ~/.wii/common-key
     - name: Install Dependencies
       run: |
         sudo apt update && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update && \
-        sudo apt install -y sox gettext libpng-dev xxd
+        sudo apt install -y gcc sox gettext libpng-dev xxd
     - name: Build WiiPAX
       run: |
         cd wiipax

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
       run: |
         sudo apt update && \
         sudo apt install -y gcc sox gettext libpng-dev xxd python2
+    - name: Install pip2 and Python Dependencies
+      run: |
+        curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2
+        pip2 install pycryptodomex
     - name: Build WiiPAX
       run: |
         cd wiipax

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build HBC
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    container: devkitpro/devkitppc
+    name: Build using devkitPPC via Docker
+    steps:
+    - uses: actions/checkout@v4
+    - name: Store Common Key
+      shell: bash
+      env:
+        WII_COMMON_KEY: ${{ secrets.WII_COMMON_KEY }}
+      run: |
+        mkdir ~/.wii/
+        echo $WII_COMMON_KEY > ~/.wii/common-key
+    - name: Build WiiPAX
+      run: |
+        cd wiipax
+        make
+    - name: Build HBC
+      run: |
+        cd channel
+        make
+    - name: Publish WAD
+      uses: actions/upload-artifact@v4
+      with:
+        path: "channel/title/channel_retail.wad"
+        name: The Homebrew Channel


### PR DESCRIPTION
Simple workflow using the devkitPPC Docker container to build the Homebrew Channel on each push and publish it as a run artifact.