### PR TITLE
(ci) Update workflow to use Python 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,8 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update && \
-        sudo apt install -y gcc sox gettext libpng-dev xxd python2
-    - name: Install pip2 and Python Dependencies
-      run: |
-        curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2
-        pip2 install pycryptodomex
+        sudo apt install -y gcc sox gettext libpng-dev xxd python3-pip
+        pip install pycryptodome
     - name: Build WiiPAX
       run: |
         cd wiipax


### PR DESCRIPTION
The Python 2 requirement has been dropped, so that section of the workflow has been removed, and now Python 3 pip is installed and used to install required dependencies.