### PR TITLE
(ci) Publish ELF and DOL from workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,4 +31,16 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         path: "channel/title/channel_retail.wad"
-        name: The Homebrew Channel
+        name: The Homebrew Channel (WAD, LULZ)
+    - name: Publish ELF
+      uses: actions/upload-artifact@v4
+      with:
+        path: "channel/channelapp/channelapp-channel.elf"
+        name: The Homebrew Channel (ELF, LULZ)
+    - name: Publish DOL
+      uses: actions/upload-artifact@v4
+      with:
+        path: "channel/channelapp/channelapp-channel.dol"
+        name: The Homebrew Channel (DOL, LULZ)
+
+      


### PR DESCRIPTION
As the title says, publish the ELF and DOL for the HBC as well as the WAD for easier debugging. Also adds "LULZ" to the artifact names to differentiate them from potential other artifacts using different TIDs.