### PR TITLE
Don't show options dialog if loading

### DIFF
--- a/channel/channelapp/source/main.c
+++ b/channel/channelapp/source/main.c
@@ -590,7 +590,7 @@ void main_real(void) {
 			}
 #endif
 			if (viewing) {
-				if ((bd & PADS_1) && !(bh & WPAD_BUTTON_2 << 16)) {
+				if ((bd & PADS_1) && !(bh & WPAD_BUTTON_2 << 16) && !loading) {
 					dialog_options_result options;
 					options = show_options_dialog(v_current);
 


### PR DESCRIPTION
This could allow for the mounted device to load apps from to be switched midread which can cause a crash.

Possible fix for #18 , still need to test it